### PR TITLE
logstash v1.5.0 -> v1.5.1 + add logstash-output-syslog plugin

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
     - logstash-input-gelf
     - logstash-input-syslog
     - logstash-codec-collectd
+    - logstash-output-syslog
   tags:
     - logstash
 

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,1 +1,1 @@
-logstash_version: 1.5.0
+logstash_version: 1.5.1


### PR DESCRIPTION
Need to bump up Logstash version to 1.5.1.

Add [logstash-output-syslog](https://github.com/logstash-plugins/logstash-output-syslog) plugin to fix this error:

```
{:timestamp=>"2015-06-23T08:33:10.647000+0000", :message=>"The error reported is: \n  Couldn't find any output plugin named 'syslog'. Are you sure this is correct? Trying to load the syslog output plugin resulted in this error: no such file to load -- logstash/outputs/syslog"}
```
