### PR TITLE
add jessie support + bump version 1.5.1->1.5.4 + fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,7 @@ logstash_elasticsearch_tcp_port: 19350
 logstash_elasticsearch_http_port: 9200
 collectd_forward_to_logstash: false
 use_elasticsearch: false
+use_loggly: false
+use_papertrail: false
+use_logentries: false
+use_graylog: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: Debian
       versions:
         - wheezy
+        - jessie
   categories:
     - monitoring
 dependencies:

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -10,13 +10,20 @@
     - pkgs
 
 - name: "Download Logstash"
+  get_url: >
+    url={{ item.link }}
+    dest={{ item.dest }}
+  with_items:
+    - { link: 'http://download.elastic.co/logstash/logstash/packages/centos/logstash-{{ logstash_version }}-1.noarch.rpm', dest: '/tmp/logstash-{{ logstash_version }}-1.noarch.rpm' }
+    - { link: 'http://download.elastic.co/logstash/logstash/packages/centos/logstash-{{ logstash_version }}-1.noarch.rpm.sha1.txt', dest: '/tmp/logstash-{{ logstash_version }}-1.noarch.rpm.sha1.txt' }
+  tags:
+    - logstash
+    - pkgs
+
+- name: "Verify Logstash checksum"
   shell: |
     executable=/bin/bash
     chdir=/tmp
-    creates=/tmp/logstash-{{ logstash_version }}-1.noarch.rpm
-    
-    curl -sS -o /tmp/logstash-{{ logstash_version }}-1.noarch.rpm http://download.elastic.co/logstash/logstash/packages/centos/logstash-{{ logstash_version }}-1.noarch.rpm
-    curl -sS -o /tmp/logstash-{{ logstash_version }}-1.noarch.rpm.sha1.txt http://download.elastic.co/logstash/logstash/packages/centos/logstash-{{ logstash_version }}-1.noarch.rpm.sha1.txt
 
     # Ansible get_url only supports sha256.
     # Elastic provides only a sha1 checksum.

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,9 +1,11 @@
 - name: "Install logstash dependencies"
   apt: >
     name={{ item }}
+    update_cache=yes
     state=present
   with_items:
     - openjdk-7-jre-headless
+    - logrotate
   tags:
     - logstash
     - pkgs
@@ -15,13 +17,20 @@
     - pkgs
 
 - name: "Download Logstash"
+  get_url: >
+    url={{ item.link }}
+    dest={{ item.dest }}
+  with_items:
+    - { link: "http://download.elastic.co/logstash/logstash/packages/debian/logstash_{{ logstash_version }}-1_all.deb", dest: "/tmp/logstash_{{ logstash_version }}-1_all.deb" }
+    - { link: "http://download.elastic.co/logstash/logstash/packages/debian/logstash_{{ logstash_version }}-1_all.deb.sha1.txt", dest: "/tmp/logstash_{{ logstash_version }}-1_all.deb.sha1.txt" }
+  tags:
+    - logstash
+    - pkgs
+
+- name: "Verify Logstash checksum"
   shell: |
     executable=/bin/bash
     chdir=/tmp
-    creates=/tmp/logstash_{{ logstash_version }}-1_all.deb
-    
-    curl -sS -o /tmp/logstash_{{ logstash_version }}-1_all.deb http://download.elastic.co/logstash/logstash/packages/debian/logstash_{{ logstash_version }}-1_all.deb
-    curl -sS -o logstash_{{ logstash_version }}-1_all.deb.sha1.txt http://download.elastic.co/logstash/logstash/packages/debian/logstash_{{ logstash_version }}-1_all.deb.sha1.txt
 
     # Ansible get_url only supports sha256.
     # Elastic provides only a sha1 checksum.

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,1 +1,1 @@
-logstash_version: 1.5.1
+logstash_version: 1.5.4


### PR DESCRIPTION
This PR:
- defaults `use_` variables to false.
- adds jessie support
- uses Ansible's `get_url` module instead of `curl` to download logstash.
- adds the `logrotate` dependency for the Debian build.
- bumps up the logstash version to 1.5.4
