### PR TITLE
fix logstash-output-syslog plugin for 1.5.4 + bump default version to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,35 @@ logstash_elasticsearch_cluster=elasticsearch1-somedc-prod
 logstash_elasticsearch_host=node1.elasticsearch1.somedc.prod
 ```
 
+#### group_vars
+
+Add more [logstash plugins](https://github.com/logstash-plugins) by simply adding plugins to your [group file](http://docs.ansible.com/ansible/intro_inventory.html#splitting-out-host-and-group-specific-data).
+
+When `logstash_version` set to 1.5.x, for example `1.5.4`, set the plugin and versions. Examples:
+
+```
+# Plugins that are compatible with 1.5.x
+logstash_version: 1.5.4
+logstash_plugins_1:
+    - { plugin_name: "logstash-input-gelf", plugin_version: "0.1.5" }
+    - { plugin_name: "logstash-input-syslog", plugin_version: "0.1.6" }
+    - { plugin_name: "logstash-codec-collectd", plugin_version: "0.1.10" }
+    - { plugin_name: "logstash-output-syslog", plugin_version: "0.1.4"}
+```
+
+
+When `logstash_version` set to 2.x.x, for example `2.1.1`, set the plugin and versions. Examples:
+
+```
+# Plugins that are compatible with 2.1.x
+logstash_version: 2.1.1
+logstash_plugins_2:
+    - { plugin_name: "logstash-input-gelf", plugin_version: "2.0.2" }
+    - { plugin_name: "logstash-input-syslog", plugin_version: "2.0.2" }
+    - { plugin_name: "logstash-codec-collectd", plugin_version: "2.0.2" }
+    - { plugin_name: "logstash-output-syslog", plugin_version: "2.1.0"}
+```
+
 ### Integration with external services
 
 When provisioning with this role, you can also add

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,12 +17,31 @@
     executable=/bin/bash
     chdir=/opt/logstash
 
-    sudo bin/plugin install {{ item }}
-  with_items:
-    - logstash-input-gelf
-    - logstash-input-syslog
-    - logstash-codec-collectd
-    - logstash-output-syslog
+    sudo bin/plugin install --version {{ item.plugin_version }} {{ item.plugin_name }}
+  with_items: logstash_plugins_1
+  when: logstash_version | version_compare('1.5.6', '<=')
+  tags:
+    - logstash
+
+- name: "Install Logstash Plugins"
+  shell: |
+    executable=/bin/bash
+    chdir=/opt/logstash
+
+    sudo bin/plugin install --version {{ item.plugin_version }} {{ item.plugin_name }}
+  with_items: logstash_plugins_2
+  when: logstash_version | version_compare('2.0.0', '>=')
+  tags:
+    - logstash
+
+# Add fix for logstash-output-syslog. See:
+# https://github.com/logstash-plugins/logstash-output-syslog/commit/f5a4be2a56f184b134c01fb1d0e0c9a09be11aa8#diff-3ccf50b4bfe2babe74a94ff1b3a791a6
+- name: "Apply fix for the logstash-output-syslog plugin"
+  get_url: >
+    url="https://raw.githubusercontent.com/logstash-plugins/logstash-output-syslog/f5a4be2a56f184b134c01fb1d0e0c9a09be11aa8/lib/logstash/outputs/syslog.rb"
+    dest="/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-syslog-0.1.4/lib/logstash/outputs/syslog.rb"
+    force=yes
+  when: logstash_version | version_compare('1.5.6', '<=')
   tags:
     - logstash
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
 
     sudo bin/plugin install --version {{ item.plugin_version }} {{ item.plugin_name }}
   with_items: logstash_plugins_1
-  when: logstash_version | version_compare('1.5.6', '<=')
+  when: logstash_version | version_compare('2.0.0', '<')
   tags:
     - logstash
 
@@ -41,7 +41,7 @@
     url="https://raw.githubusercontent.com/logstash-plugins/logstash-output-syslog/f5a4be2a56f184b134c01fb1d0e0c9a09be11aa8/lib/logstash/outputs/syslog.rb"
     dest="/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-syslog-0.1.4/lib/logstash/outputs/syslog.rb"
     force=yes
-  when: logstash_version | version_compare('1.5.6', '<=')
+  when: logstash_version | version_compare('2.0.0', '<')
   tags:
     - logstash
 

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,1 +1,16 @@
 logstash_version: 1.5.4
+
+# Plugins that are compatible with 1.5.x
+logstash_plugins_1:
+    - { plugin_name: "logstash-input-gelf", plugin_version: "0.1.5" }
+    - { plugin_name: "logstash-input-syslog", plugin_version: "0.1.6" }
+    - { plugin_name: "logstash-codec-collectd", plugin_version: "0.1.10" }
+    - { plugin_name: "logstash-output-syslog", plugin_version: "0.1.4"}
+
+
+# Plugins that are compatible with 2.1.x
+logstash_plugins_2:
+    - { plugin_name: "logstash-input-gelf", plugin_version: "2.0.2" }
+    - { plugin_name: "logstash-input-syslog", plugin_version: "2.0.2" }
+    - { plugin_name: "logstash-codec-collectd", plugin_version: "2.0.2" }
+    - { plugin_name: "logstash-output-syslog", plugin_version: "2.1.0"}

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -1,4 +1,4 @@
-logstash_version: 1.5.4
+logstash_version: 2.1.1
 
 # Plugins that are compatible with 1.5.x
 logstash_plugins_1:


### PR DESCRIPTION
The current stable version of Logstash is 1.5.4. The plugins just released versions require >= 2.0.0.

This PR pins the working versions of the plugins with logstash 1.5.4 + applies the fix for this [error](https://github.com/logstash-plugins/logstash-output-syslog/issues/11):

```
==> logstash.err <==
TypeError: can't convert nil into String
              + at org/jruby/RubyString.java:1172
        receive at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-syslog-0.1.4/lib/logstash/outputs/syslog.rb:127
         handle at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.1-java/lib/logstash/outputs/base.rb:88
    output_func at (eval):314
   outputworker at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.1-java/lib/logstash/pipeline.rb:243
  start_outputs at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.1-java/lib/logstash/pipeline.rb:165
```
